### PR TITLE
Avoid clearing fresh normalization bitmap

### DIFF
--- a/src/hvm.c
+++ b/src/hvm.c
@@ -5722,7 +5722,7 @@ typedef struct {
   u64 word_count;
 } Uset;
 
-// Initialize bitset storage.
+// Initialize empty bitset storage from a zero-filled anonymous mapping.
 fn void uset_init(Uset *set) {
   set->word_count = HEAP_CAP >> 6;
   set->words      = NULL;
@@ -5758,11 +5758,6 @@ fn u8 uset_add(Uset *set, u64 key) {
   u64 prev = set->words[word_idx];
   set->words[word_idx] = prev | bit_mask;
   return (prev & bit_mask) == 0;
-}
-
-// Clear all visited bits.
-fn void uset_clear(Uset *set) {
-  memset(set->words, 0, (size_t)(set->word_count * sizeof(u64)));
 }
 
 // CNF
@@ -6009,7 +6004,6 @@ fn Term eval_normalize(Term term) {
   EvalNormalizeStack stack;
   uset_init(&seen);
   eval_normalize_stack_init(&stack);
-  uset_clear(&seen);
   eval_normalize_stack_push(&stack, root_loc);
 
   u64 loc = 0;


### PR DESCRIPTION
## Summary

Avoid clearing the normalization visited bitmap immediately after allocating it.

`uset_init()` obtains fresh `MAP_ANONYMOUS` storage, which is already zero-filled. The subsequent `uset_clear()` touched the entire 512 MiB bitmap before every normal evaluation without changing its contents. This removes that call and the now-unused helper, while documenting the initialization invariant.

## Measurements

Measured on an Apple M5 with Apple Clang 21 (`clang -O2`):

- Trivial program median peak RSS: 538,443,776 B -> 1,605,632 B
- Avoided approximately 32,766 page reclaims per run
- `lambda_eval` median evaluation time: 1.528 s -> 1.481 s
- `cnot_24` median evaluation time: 1.207 s -> 1.201 s

The primary benefit is avoiding a fixed 512 MiB resident-memory cost; timing gains are workload-dependent.

## Validation

- `./devs/test/_all_.sh`: 217 passed
- Normal-mode differential over all 218 test files: byte-identical output and matching exit behavior
- Identical interaction and heap-allocation counts on measured benchmarks
- Clean builds with `-O0`, `-O2`, `-O3`, and `-Os`
- Representative normal-form programs passed AddressSanitizer and UndefinedBehaviorSanitizer
